### PR TITLE
update workflow files

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,8 +6,8 @@
 #
 
 version: 2
-updates:
 
+updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     ignore:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,3 +20,16 @@ updates:
       interval: "daily"
       time: "04:00"
     target-branch: "main"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 10
+    reviewers:
+      - "xh3b4sd"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    target-branch: "main"

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -13,7 +13,6 @@ jobs:
   go-build:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 
@@ -28,7 +27,7 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - name: "Build Go Binary"
+      - name: "Run Go Build"
         env:
           CGO_ENABLED: "0"
         run: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -28,6 +28,12 @@ jobs:
           go mod tidy
           git diff --exit-code
 
+      - name: "Build Go Binary"
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          go build .
+
       - name: "Check Go Tests"
         run: |
           go test ./... -race

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -2,7 +2,7 @@
 # Do not edit. This file was generated via the "workflow" command line tool.
 # More information about the tool can be found at github.com/xh3b4sd/workflow.
 #
-#     workflow create golang
+#     workflow create golang --binary=false
 #
 
 name: "go-build"
@@ -32,7 +32,7 @@ jobs:
         env:
           CGO_ENABLED: "0"
         run: |
-          go build .
+          go build ./...
 
       - name: "Check Go Tests"
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xSplits/spectagocode
 
-go 1.24.3
+go 1.24
 
 require (
 	github.com/twitchtv/twirp v8.1.3+incompatible


### PR DESCRIPTION
We see some inconsistencies between the Go projects that we are managing with the `workflow` tool. This PR tries to streamline the Go version format specified in the `go.mod` file so that those inconsistencies get fixed.